### PR TITLE
Fix a variable typo

### DIFF
--- a/Python/PortScanner/PortScanner.py
+++ b/Python/PortScanner/PortScanner.py
@@ -314,7 +314,7 @@ def check_port(ip, port):
 
 if __name__ == '__main__':
     if sys.platform == 'linux-i386' or sys.platform == 'linux2' or sys.platform == 'darwin':
-        SysClS = 'clear'
+        SysCls = 'clear'
         os.system(SysCls)
     elif sys.platform == 'win32' or sys.platform == 'dos' or sys.platform[0:5] == 'ms-dos':
         SysCls = 'cls'

--- a/Python/PortScanner_WithColor/PortScanner_WithColor.py
+++ b/Python/PortScanner_WithColor/PortScanner_WithColor.py
@@ -323,7 +323,7 @@ def check_port(ip, port):
 
 if __name__ == '__main__':
     if sys.platform == 'linux-i386' or sys.platform == 'linux2' or sys.platform == 'darwin':
-        SysClS = 'clear'
+        SysCls = 'clear'
         os.system(SysCls)
     elif sys.platform == 'win32' or sys.platform == 'dos' or sys.platform[0:5] == 'ms-dos':
         SysCls = 'cls'


### PR DESCRIPTION
The variable `SysCls` was used as `SysClS` in one spot in the python scripts. Quick PR to fix that.
